### PR TITLE
Changed command to use $PWD instead of `pwd`, because paths cant appe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This can take a considerable amount of time as the stage where it downloads `htt
 Once the docker image has been built you can copy the code out of the image using:
 
 ```
-docker run -v `pwd`/lib:/dst -t tflite-generator
+docker run -v $PWD/lib:/dst -t tflite-generator
 ```
 
 This will copy the `tfmicro` source code for the ESP32 into a folder called `lib`.


### PR DESCRIPTION
Changed command to use $PWD instead of `pwd`, because paths cant append to `pwd`.

Fails with:
docker: Error response from daemon: create pwd/lib: "pwd/lib" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.